### PR TITLE
Добавляет вариант дял препроцессора Sass(Scss)

### DIFF
--- a/nebo.scss
+++ b/nebo.scss
@@ -1,0 +1,131 @@
+@use "sass:meta";
+@use "sass:map";
+
+// Базовые CSS-переменные
+.nebo {
+  --nb-r: 20px;
+  --nb-w: 20px;
+  --nb-h: 20px;
+  --_nb-smooth: 98%;
+}
+
+// Миксин для генерации mask-свойств
+@mixin apply-nebo-corner(
+  $r: var(--nb-r),
+  $w: var(--nb-w),
+  $h: var(--nb-h),
+  $corner: "br"
+) {
+  // Проверка типа с использованием meta.type-of
+  $radius: if(meta.type-of($r) == "number", $r, var(--nb-r));
+  $width: if(meta.type-of($w) == "number", $w, var(--nb-w));
+  $height: if(meta.type-of($h) == "number", $h, var(--nb-h));
+  $smooth: var(--_nb-smooth);
+
+  // Позиция скругления с использованием map.get
+  $positions: (
+    "tl": 0 0,
+    "tr": 100% 0,
+    "bl": 0 100%,
+    "br": 100% 100%,
+  );
+  $curve-pos: map.get($positions, $corner);
+
+  // Генерация mask-image
+  $mask-image:
+    linear-gradient(to bottom, #000, #000),
+    linear-gradient(to bottom, #000, #000),
+    linear-gradient(to bottom, #000, #000),
+    linear-gradient(to bottom, #000, #000),
+    radial-gradient(
+      circle closest-side at center,
+      #000 $smooth,
+      transparent 100%
+    ),
+    radial-gradient(
+      circle closest-side at center,
+      #000 $smooth,
+      transparent 100%
+    ),
+    radial-gradient(
+      circle farthest-side at #{$curve-pos},
+      transparent $smooth,
+      #000 100%
+    );
+
+  // Генерация mask-size
+  $mask-size:
+    100% calc(100% - #{$height} - #{$radius} * 3),
+    calc(100% - #{$radius}) calc(100% - #{$height} - #{$radius} * 2),
+    calc(100% - #{$width} - #{$radius} * 2) calc(100% - #{$radius}),
+    calc(100% - #{$width} - #{$radius} * 3) 100%,
+    calc(#{$radius} * 2) calc(#{$radius} * 2),
+    calc(#{$radius} * 2) calc(#{$radius} * 2),
+    calc(#{$radius} + 0.5px) calc(#{$radius} + 0.5px);
+
+  // Генерация mask-position с использованием map.get
+  $mask-positions: (
+    "tl": (
+      100% 100%,
+      100% 100%,
+      100% 100%,
+      100% 100%,
+      0 calc(#{$height} + #{$radius} * 2),
+      calc(#{$width} + #{$radius} * 2) 0,
+      calc(#{$width} + #{$radius}) calc(#{$height} + #{$radius}),
+    ),
+    "tr": (
+      0 100%,
+      0 100%,
+      0 100%,
+      0 100%,
+      100% calc(#{$height} + #{$radius} * 2),
+      calc(100% - #{$width} - #{$radius} * 2) 0,
+      calc(100% - #{$width} - #{$radius}) calc(#{$height} + #{$radius}),
+    ),
+    "bl": (
+      100% 0,
+      100% 0,
+      100% 0,
+      100% 0,
+      0 calc(100% - #{$height} - #{$radius} * 2),
+      calc(#{$width} + #{$radius} * 2) 100%,
+      calc(#{$width} + #{$radius}) calc(100% - #{$height} - #{$radius}),
+    ),
+    "br": (
+      0 0,
+      0 0,
+      0 0,
+      0 0,
+      100% calc(100% - #{$height} - #{$radius} * 2),
+      calc(100% - #{$width} - #{$radius} * 2) 100%,
+      calc(100% - #{$width} - #{$radius}) calc(100% - #{$height} - #{$radius}),
+    ),
+  );
+  $mask-position: map.get($mask-positions, $corner);
+
+  // Применение стилей
+  mask-image: $mask-image;
+  mask-size: $mask-size;
+  mask-position: $mask-position;
+  mask-repeat: no-repeat;
+}
+
+// Базовый класс
+.nebo {
+  @include apply-nebo-corner();
+
+  // Модификаторы углов
+  &--tl {
+    @include apply-nebo-corner($corner: "tl");
+  }
+  &--tr {
+    @include apply-nebo-corner($corner: "tr");
+  }
+  &--bl {
+    @include apply-nebo-corner($corner: "bl");
+  }
+  &--br {
+    @include apply-nebo-corner($corner: "br");
+  }
+}

--- a/nebo.scss
+++ b/nebo.scss
@@ -1,121 +1,115 @@
 @use "sass:meta";
-@use "sass:map";
 
-// Базовые CSS-переменные
 .nebo {
   --nb-r: 20px;
   --nb-w: 20px;
   --nb-h: 20px;
+
   --_nb-smooth: 98%;
-}
 
-// Миксин для генерации mask-свойств
-@mixin apply-nebo-corner(
-  $r: var(--nb-r),
-  $w: var(--nb-w),
-  $h: var(--nb-h),
-  $corner: "br"
-) {
-  // Проверка типа с использованием meta.type-of
-  $radius: if(meta.type-of($r) == "number", $r, var(--nb-r));
-  $width: if(meta.type-of($w) == "number", $w, var(--nb-w));
-  $height: if(meta.type-of($h) == "number", $h, var(--nb-h));
-  $smooth: var(--_nb-smooth);
+  /* Curve positions list */
+  --_nb-curve-pos-tl: 0 0;
+  --_nb-curve-pos-tr: 100% 0;
+  --_nb-curve-pos-bl: 0 100%;
+  --_nb-curve-pos-br: 100% 100%;
 
-  // Позиция скругления с использованием map.get
-  $positions: (
-    "tl": 0 0,
-    "tr": 100% 0,
-    "bl": 0 100%,
-    "br": 100% 100%,
-  );
-  $curve-pos: map.get($positions, $corner);
+  /* Setting default curve position (bottom right corner) */
+  --_nb-curve-pos: var(--_nb-curve-pos-br);
 
-  // Генерация mask-image
-  $mask-image:
+  --_nb-mask-image:
     linear-gradient(to bottom, #000, #000),
     linear-gradient(to bottom, #000, #000),
     linear-gradient(to bottom, #000, #000),
     linear-gradient(to bottom, #000, #000),
     radial-gradient(
       circle closest-side at center,
-      #000 $smooth,
+      #000 var(--_nb-smooth),
       transparent 100%
     ),
     radial-gradient(
       circle closest-side at center,
-      #000 $smooth,
+      #000 var(--_nb-smooth),
       transparent 100%
     ),
     radial-gradient(
-      circle farthest-side at #{$curve-pos},
-      transparent $smooth,
+      circle farthest-side at var(--_nb-curve-pos),
+      transparent var(--_nb-smooth),
       #000 100%
     );
 
-  // Генерация mask-size
-  $mask-size:
-    100% calc(100% - #{$height} - #{$radius} * 3),
-    calc(100% - #{$radius}) calc(100% - #{$height} - #{$radius} * 2),
-    calc(100% - #{$width} - #{$radius} * 2) calc(100% - #{$radius}),
-    calc(100% - #{$width} - #{$radius} * 3) 100%,
-    calc(#{$radius} * 2) calc(#{$radius} * 2),
-    calc(#{$radius} * 2) calc(#{$radius} * 2),
-    calc(#{$radius} + 0.5px) calc(#{$radius} + 0.5px);
+  --_nb-mask-size:
+    100% calc(100% - var(--nb-h) - var(--nb-r) * 3),
+    calc(100% - var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r) * 2),
+    calc(100% - var(--nb-w) - var(--nb-r) * 2) calc(100% - var(--nb-r)),
+    calc(100% - var(--nb-w) - var(--nb-r) * 3) 100%,
+    calc(var(--nb-r) * 2) calc(var(--nb-r) * 2),
+    calc(var(--nb-r) * 2) calc(var(--nb-r) * 2),
+    calc(var(--nb-r) + 0.5px) calc(var(--nb-r) + 0.5px);
 
-  // Генерация mask-position с использованием map.get
-  $mask-positions: (
-    "tl": (
-      100% 100%,
-      100% 100%,
-      100% 100%,
-      100% 100%,
-      0 calc(#{$height} + #{$radius} * 2),
-      calc(#{$width} + #{$radius} * 2) 0,
-      calc(#{$width} + #{$radius}) calc(#{$height} + #{$radius}),
-    ),
-    "tr": (
-      0 100%,
-      0 100%,
-      0 100%,
-      0 100%,
-      100% calc(#{$height} + #{$radius} * 2),
-      calc(100% - #{$width} - #{$radius} * 2) 0,
-      calc(100% - #{$width} - #{$radius}) calc(#{$height} + #{$radius}),
-    ),
-    "bl": (
-      100% 0,
-      100% 0,
-      100% 0,
-      100% 0,
-      0 calc(100% - #{$height} - #{$radius} * 2),
-      calc(#{$width} + #{$radius} * 2) 100%,
-      calc(#{$width} + #{$radius}) calc(100% - #{$height} - #{$radius}),
-    ),
-    "br": (
-      0 0,
-      0 0,
-      0 0,
-      0 0,
-      100% calc(100% - #{$height} - #{$radius} * 2),
-      calc(100% - #{$width} - #{$radius} * 2) 100%,
-      calc(100% - #{$width} - #{$radius}) calc(100% - #{$height} - #{$radius}),
-    ),
-  );
-  $mask-position: map.get($mask-positions, $corner);
+  /* Masks positions list */
+  --_nb-mask-position-tl:
+    100% 100%, 100% 100%, 100% 100%, 100% 100%,
+    0 calc(var(--nb-h) + var(--nb-r) * 2),
+    calc(var(--nb-w) + var(--nb-r) * 2) 0,
+    calc(var(--nb-w) + var(--nb-r)) calc(var(--nb-h) + var(--nb-r)),
+    calc(var(--nb-w) + var(--nb-r)) calc(var(--nb-h) + var(--nb-r));
 
-  // Применение стилей
-  mask-image: $mask-image;
-  mask-size: $mask-size;
-  mask-position: $mask-position;
+  --_nb-mask-position-tr:
+    0 100%, 0 100%, 0 100%, 0 100%, 100% calc(var(--nb-h) + var(--nb-r) * 2),
+    calc(100% - var(--nb-w) - var(--nb-r) * 2) 0,
+    calc(100% - var(--nb-w) - var(--nb-r)) calc(var(--nb-h) + var(--nb-r)),
+    calc(100% - var(--nb-w) - var(--nb-r)) calc(var(--nb-h) + var(--nb-r));
+
+  --_nb-mask-position-bl:
+    100% 0, 100% 0, 100% 0, 100% 0,
+    0 calc(100% - var(--nb-h) - var(--nb-r) * 2),
+    calc(var(--nb-w) + var(--nb-r) * 2) 100%,
+    calc(var(--nb-w) + var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r)),
+    calc(var(--nb-w) + var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r));
+
+  --_nb-mask-position-br:
+    0 0, 0 0, 0 0, 0 0, 100% calc(100% - var(--nb-h) - var(--nb-r) * 2),
+    calc(100% - var(--nb-w) - var(--nb-r) * 2) 100%,
+    calc(100% - var(--nb-w) - var(--nb-r))
+      calc(100% - var(--nb-h) - var(--nb-r));
+
+  /* Setting default mask position (bottom right corner) */
+  --_nb-mask-position: var(--_nb-mask-position-br);
+
+  mask-image: var(--_nb-mask-image);
+  mask-size: var(--_nb-mask-size);
+  mask-position: var(--_nb-mask-position);
   mask-repeat: no-repeat;
 }
 
-// Базовый класс
+// Mixin with optional parameters
+@mixin apply-nebo-corner(
+  $radius: null,
+  $width: null,
+  $height: null,
+  $corner: null
+) {
+  // Apply custom values only if provided
+  @if $radius != null {
+    --nb-r: #{$radius};
+  }
+  @if $width != null {
+    --nb-w: #{$width};
+  }
+  @if $height != null {
+    --nb-h: #{$height};
+  }
+  @if $corner != null {
+    --_nb-curve-pos: var(--_nb-curve-pos-#{$corner});
+    --_nb-mask-position: var(--_nb-mask-position-#{$corner});
+  }
+}
+
+// Base class
 .nebo {
   @include apply-nebo-corner();
 
-  // Модификаторы углов
+  //
   &--tl {
     @include apply-nebo-corner($corner: "tl");
   }

--- a/nebo.scss
+++ b/nebo.scss
@@ -1,9 +1,15 @@
-@use "sass:meta";
-
 .nebo {
   --nb-r: 20px;
   --nb-w: 20px;
   --nb-h: 20px;
+
+  /* Fine-tuned radiuses */
+  --nb-cor1-rw: var(--nb-r);
+  --nb-cor1-rh: var(--nb-r);
+  --nb-cor2-rw: var(--nb-r);
+  --nb-cor2-rh: var(--nb-r);
+  --nb-curve-rw: var(--nb-r);
+  --nb-curve-rh: var(--nb-r);
 
   --_nb-smooth: 98%;
 
@@ -16,62 +22,62 @@
   /* Setting default curve position (bottom right corner) */
   --_nb-curve-pos: var(--_nb-curve-pos-br);
 
+  /* Corner mask shapes */
   --_nb-mask-image:
-    linear-gradient(to bottom, #000, #000),
-    linear-gradient(to bottom, #000, #000),
-    linear-gradient(to bottom, #000, #000),
-    linear-gradient(to bottom, #000, #000),
-    radial-gradient(
-      circle closest-side at center,
-      #000 var(--_nb-smooth),
-      transparent 100%
-    ),
-    radial-gradient(
-      circle closest-side at center,
-      #000 var(--_nb-smooth),
-      transparent 100%
-    ),
-    radial-gradient(
-      circle farthest-side at var(--_nb-curve-pos),
-      transparent var(--_nb-smooth),
-      #000 100%
-    );
+    linear-gradient(to bottom, #000 0 100%),
+    linear-gradient(to bottom, #000 0 100%),
+    linear-gradient(to bottom, #000 0 100%),
+    linear-gradient(to bottom, #000 0 100%),
+    radial-gradient(closest-side at center, #000 var(--_nb-smooth), transparent 100%),
+    radial-gradient(closest-side at center, #000 var(--_nb-smooth), transparent 100%),
+    radial-gradient(farthest-side at var(--_nb-curve-pos), transparent var(--_nb-smooth), #000 100%);
 
+  /* Corner mask sizes */
   --_nb-mask-size:
-    100% calc(100% - var(--nb-h) - var(--nb-r) * 3),
-    calc(100% - var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r) * 2),
-    calc(100% - var(--nb-w) - var(--nb-r) * 2) calc(100% - var(--nb-r)),
-    calc(100% - var(--nb-w) - var(--nb-r) * 3) 100%,
-    calc(var(--nb-r) * 2) calc(var(--nb-r) * 2),
-    calc(var(--nb-r) * 2) calc(var(--nb-r) * 2),
-    calc(var(--nb-r) + 0.5px) calc(var(--nb-r) + 0.5px);
+    100% calc(100% - var(--nb-h) - var(--nb-cor1-rh) - var(--nb-curve-rh) - var(--nb-cor2-rh)),
+    calc(100% - var(--nb-cor1-rw)) calc(100% - var(--nb-h) - var(--nb-curve-rh) - var(--nb-cor2-rh)),
+    calc(100% - var(--nb-w) - var(--nb-curve-rw) - var(--nb-cor1-rw)) calc(100% - var(--nb-cor2-rh)),
+    calc(100% - var(--nb-w) - var(--nb-cor1-rw) - var(--nb-curve-rw) - var(--nb-cor2-rw)) 100%,
+    calc(var(--nb-cor1-rw) * 2) calc(var(--nb-cor1-rh) * 2),
+    calc(var(--nb-cor2-rw) * 2) calc(var(--nb-cor2-rh) * 2),
+    calc(var(--nb-curve-rw) + 0.5px) calc(var(--nb-curve-rh) + 0.5px);
 
   /* Masks positions list */
   --_nb-mask-position-tl:
-    100% 100%, 100% 100%, 100% 100%, 100% 100%,
-    0 calc(var(--nb-h) + var(--nb-r) * 2),
-    calc(var(--nb-w) + var(--nb-r) * 2) 0,
-    calc(var(--nb-w) + var(--nb-r)) calc(var(--nb-h) + var(--nb-r)),
-    calc(var(--nb-w) + var(--nb-r)) calc(var(--nb-h) + var(--nb-r));
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    100% 100%,
+    0 calc(var(--nb-h) + var(--nb-curve-rh) + var(--nb-cor2-rh)),
+    calc(var(--nb-w) + var(--nb-cor1-rw) + var(--nb-curve-rw)) 0,
+    calc(var(--nb-w) + var(--nb-cor1-rw)) calc(var(--nb-h) + var(--nb-cor2-rh));
 
   --_nb-mask-position-tr:
-    0 100%, 0 100%, 0 100%, 0 100%, 100% calc(var(--nb-h) + var(--nb-r) * 2),
-    calc(100% - var(--nb-w) - var(--nb-r) * 2) 0,
-    calc(100% - var(--nb-w) - var(--nb-r)) calc(var(--nb-h) + var(--nb-r)),
-    calc(100% - var(--nb-w) - var(--nb-r)) calc(var(--nb-h) + var(--nb-r));
+    0 100%,
+    0 100%,
+    0 100%,
+    0 100%,
+    100% calc(var(--nb-h) + var(--nb-curve-rh) + var(--nb-cor2-rh)),
+    calc(100% - var(--nb-w) - var(--nb-curve-rw) - var(--nb-cor1-rw)) 0,
+    calc(100% - var(--nb-w) - var(--nb-cor1-rw)) calc(var(--nb-h) + var(--nb-cor2-rh));
 
   --_nb-mask-position-bl:
-    100% 0, 100% 0, 100% 0, 100% 0,
-    0 calc(100% - var(--nb-h) - var(--nb-r) * 2),
-    calc(var(--nb-w) + var(--nb-r) * 2) 100%,
-    calc(var(--nb-w) + var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r)),
-    calc(var(--nb-w) + var(--nb-r)) calc(100% - var(--nb-h) - var(--nb-r));
+    100% 0,
+    100% 0,
+    100% 0,
+    100% 0,
+    0 calc(100% - var(--nb-h) - var(--nb-curve-rh) - var(--nb-cor2-rh)),
+    calc(var(--nb-w) + var(--nb-curve-rw) + var(--nb-cor1-rw)) 100%,
+    calc(var(--nb-w) + var(--nb-cor1-rw)) calc(100% - var(--nb-h) - var(--nb-cor2-rh));
 
   --_nb-mask-position-br:
-    0 0, 0 0, 0 0, 0 0, 100% calc(100% - var(--nb-h) - var(--nb-r) * 2),
-    calc(100% - var(--nb-w) - var(--nb-r) * 2) 100%,
-    calc(100% - var(--nb-w) - var(--nb-r))
-      calc(100% - var(--nb-h) - var(--nb-r));
+    0 0,
+    0 0,
+    0 0,
+    0 0,
+    100% calc(100% - var(--nb-h) - var(--nb-curve-rh) - var(--nb-cor2-rh)),
+    calc(100% - var(--nb-w) - var(--nb-curve-rw) - var(--nb-cor1-rw)) 100%,
+    calc(100% - var(--nb-w) - var(--nb-cor1-rw)) calc(100% - var(--nb-h) - var(--nb-cor2-rh));
 
   /* Setting default mask position (bottom right corner) */
   --_nb-mask-position: var(--_nb-mask-position-br);
@@ -82,43 +88,82 @@
   mask-repeat: no-repeat;
 }
 
-// Mixin with optional parameters
+/* Mixin with optional parameters */
 @mixin apply-nebo-corner(
   $radius: null,
+
+  $cor1-rw: null,
+  $cor1-rh: null,
+  $cor2-rw: null,
+  $cor2-rh: null,
+  $curve-rw: null,
+  $curve-rh: null,
+
   $width: null,
   $height: null,
   $corner: null
 ) {
-  // Apply custom values only if provided
+  /* Apply custom shared radius if provided  */
   @if $radius != null {
-    --nb-r: #{$radius};
+    --nb-r:        #{$radius};
+    --nb-cor1-rw:  #{$radius};
+    --nb-cor1-rh:  #{$radius};
+    --nb-cor2-rw:  #{$radius};
+    --nb-cor2-rh:  #{$radius};
+    --nb-curve-rw: #{$radius};
+    --nb-curve-rh: #{$radius};
   }
+
+  /* Apply custom values only if provided */
+  @if $cor1-rw != null {
+    --nb-cor1-rw: #{$cor1-rw};
+  }
+  @if $cor1-rh != null {
+    --nb-cor1-rh: #{$cor1-rh};
+  }
+  @if $cor2-rw != null {
+    --nb-cor2-rw: #{$cor2-rw};
+  }
+  @if $cor2-rh != null {
+    --nb-cor2-rh: #{$cor2-rh};
+  }
+  @if $curve-rw != null {
+    --nb-curve-rw: #{$curve-rw};
+  }
+  @if $curve-rh != null {
+    --nb-curve-rh: #{$curve-rh};
+  }
+
   @if $width != null {
     --nb-w: #{$width};
   }
   @if $height != null {
     --nb-h: #{$height};
   }
-  @if $corner != null {
+
+  /* Curve position override (safe corner check) */
+  @if $corner == "tl" or $corner == "tr" or $corner == "bl" or $corner == "br" {
     --_nb-curve-pos: var(--_nb-curve-pos-#{$corner});
     --_nb-mask-position: var(--_nb-mask-position-#{$corner});
   }
 }
 
-// Base class
+  /* Base class */
 .nebo {
   @include apply-nebo-corner();
 
-  //
   &--tl {
     @include apply-nebo-corner($corner: "tl");
   }
+
   &--tr {
     @include apply-nebo-corner($corner: "tr");
   }
+
   &--bl {
     @include apply-nebo-corner($corner: "bl");
   }
+
   &--br {
     @include apply-nebo-corner($corner: "br");
   }


### PR DESCRIPTION
В файле nebo.scss в классе .nebo сохранены исходные css-переменные по аналогии с файлом nebo.css Можно использовать все, что доступно в классе nebo.css - переопределять css-переменные, использовать модификаторы Так же можно использовать миксин apply-nebo-corner() - без аргументов он принимает значения по-умолчанию (как в файле nebo.css) Миксин принимает 4 аргумента - $r (радиус), $w (ширина), $h (высота) и $corner (угол - строка, возможные варианты: "tl", "tr", "bl" и "br")